### PR TITLE
Fix bug qui désactive la vérification du texte tapé sous MacOS

### DIFF
--- a/bepodactyl/js/fonctions_texte.js
+++ b/bepodactyl/js/fonctions_texte.js
@@ -111,8 +111,10 @@ function ligne_suivante(reload)
 	}
 	else if (recommencer == true && nb_recom >= (nb_tentatives_recom-1) )
 	{
-		if (le_texte[l-1])
-			le_texte[le_texte.length] = le_texte[l-1];
+		if (le_texte[l-1]) {
+			le_texte[le_texte.length] = le_texte[l - 1];
+			le_texte_alt[le_texte_alt.length] = le_texte_alt[l-1];
+		}
 		nb_recom = 0;
 	}
 	//else if (recommencer == false && nb_recom < (nb_tentatives_recom-1))


### PR DESCRIPTION
L'erreur dans la console n'arrive que sur Mac.

Lorsqu'une ligne doit être recommencée après 3 échecs, elle est ajoutée à la fin du tableau `le_texte`.
Cette opération n'était pas faite sur le tableau du compatibilité MacOS `le_texte_alt`.

Pour reproduire le problème:
* faire en sorte d'utiliser le tableau MacOS
* se tromper 3 fois par ligne jusqu'à arriver après la dernière ligne
* l'erreur apparrait

Fixes #33 